### PR TITLE
simplify and expand test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
   - 1.9.3
-  - 2.0.0
   - 2.1.0
 env:
   - PUPPET_GEM_VERSION="~> 3.2.0"
@@ -14,22 +12,14 @@ env:
   - PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 4.2.0" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 4.3.0" STRICT_VARIABLES=yes
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
   exclude:
-    # Ruby 1.8.7
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.2.0" STRICT_VARIABLES=yes
-
-    # Ruby 2.1.0
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 3.2.0"
     - rvm: 2.1.0


### PR DESCRIPTION
* there's no point testing all these ruby versions if there's no ruby code in this module
* there's no point using the future parser in puppet 3.x if we already run tests in puppet 4.x
* test on puppet 3.8 and puppet 4.3 