### PR TITLE
Autofix kmod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,6 @@ matrix:
   - rvm: 2.1
     env: PUPPET_GEM_VERSION="~> 4.0"   STRICT_VARIABLES=yes
 
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.2.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
   - rvm: 2.1
     env: PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
   - rvm: 2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0 - 2017-06-27
+- add management of the hcpdriver kmod
+
 ## 2.0.0 - 2016-08-20
 - the managemnt of the r1sfot repo repo is a separate class now. it can still be
   installed through the agent.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Specify a list of keys to place on the r1soft agent server. Default value: empty
 Specify if you want to purge all keys not managed by puppet: Default value: false
 
 #### `kmod_tool`
-Specify the path to the hcp kmod build/retrieval tool: Default value: `/usr/sbin/hcp-setup`
+Specify the path to the hcp kmod build/retrieval tool: Default value: `/usr/bin/r1soft-setup`
 
 #### `kmod_manage`
 Specify if you want puppet to trigger kmod builds (and service restarts): Default value: false
@@ -192,6 +192,8 @@ it.
 * `r1soft_agent_version`: r1soft version and build number. eg `5.12.0-21`
 * `r1soft_agent_version_short`: r1soft version number. eg `5.12.0`
 * `r1soft_agent_version_long`: r1soft version number, build number, and build date. eg `5.12.0 build 21 2015/08/26 20:31:22`
+* `hcpdriver_installed`: whether the hcp driver executable is available `true/false`
+* `hcpdriver`: a hash of info about the hcpdriver kmod
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Specify a list of keys to place on the r1soft agent server. Default value: empty
 #### `keys_purge_unmanaged`
 Specify if you want to purge all keys not managed by puppet: Default value: false
 
+#### `kmod_tool`
+Specify the path to the hcp kmod build/retrieval tool: Default value: `/usr/sbin/hcp-setup`
+
+#### `kmod_manage`
+Specify if you want puppet to trigger kmod builds (and service restarts): Default value: false
+
 
 ### r1soft::server parameters
 

--- a/lib/facter/hcpdriver.rb
+++ b/lib/facter/hcpdriver.rb
@@ -2,7 +2,7 @@ Facter.add(:hcpdriver_installed) do
     confine :kernel => 'Linux'
 
     setcode do
-        File.exist? '/usr/sbin/hcp-setup'
+        File.executable? '/usr/sbin/hcp'
     end
 end
 

--- a/lib/facter/hcpdriver.rb
+++ b/lib/facter/hcpdriver.rb
@@ -1,0 +1,26 @@
+Facter.add(:hcpdriver_installed) do
+    confine :kernel => 'Linux'
+
+    setcode do
+        File.exist? '/usr/sbin/hcp-setup'
+    end
+end
+
+Facter.add(:hcpdriver) do
+    confine :kernel => 'Linux'
+    confine :hcpdriver_installed => true
+
+    setcode do
+        fact_data = Hash.new
+        fact_data[:is_loaded] = File.exist? '/sys/module/hcpdriver/version'
+        if fact_data[:is_loaded]
+            fact_data[:version] = File.read('/sys/module/hcpdriver/version').strip
+        end
+        fact_data[:kmod_wanted] = '/lib/modules/r1soft/hcpdriver-cki-%s.ko' % Facter.value(:kernelrelease)
+        fact_data[:kmod_wanted_is_built] = File.exist? fact_data[:kmod_wanted]
+        fact_data[:kmod_selected] = File.exist?('/lib/modules/r1soft/hcpdriver.o') \
+            ? File.readlink('/lib/modules/r1soft/hcpdriver.o') \
+            : ''
+        fact_data
+    end
+end

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -33,12 +33,12 @@ inherits r1soft::params {
     Yumrepo['r1soft'] -> Package <| title == $package_name |>
   }
 
-  anchor {'r1soft::agent::begin':} ->
-  class{'::r1soft::agent::kernel_package':} ->
-  class{'::r1soft::agent::install':} ->
-  class{'::r1soft::agent::service':} ->
-  class{'::r1soft::agent::keys':} ->
-  anchor {'r1soft::agent::end':}
+  anchor {'r1soft::agent::begin':}
+  -> class{'::r1soft::agent::kernel_package':}
+  -> class{'::r1soft::agent::install':}
+  -> class{'::r1soft::agent::service':}
+  -> class{'::r1soft::agent::keys':}
+  -> anchor {'r1soft::agent::end':}
 
   class{'::r1soft::agent::hcpdriver':}
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -10,6 +10,8 @@ class r1soft::agent (
   $service_enable             = $r1soft::params::agent_service_enable,
   $keys                       = $r1soft::params::keys,
   $keys_purge_unmanaged       = $r1soft::params::keys_purge_unmanaged,
+  $kmod_tool                  = $r1soft::params::agent_kmod_tool,
+  $kmod_manage                = $r1soft::params::agent_kmod_manage,
 )
 inherits r1soft::params {
   validate_bool($repo_install)
@@ -23,6 +25,8 @@ inherits r1soft::params {
   validate_bool($service_enable)
   validate_hash($keys)
   validate_bool($keys_purge_unmanaged)
+  validate_string($kmod_tool)
+  validate_bool($kmod_manage)
 
   if $repo_install {
     include r1soft::repo
@@ -33,6 +37,7 @@ inherits r1soft::params {
   class{'::r1soft::agent::kernel_package':} ->
   class{'::r1soft::agent::install':} ->
   class{'::r1soft::agent::service':} ->
+  class{'::r1soft::agent::hcpdriver':} ->
   class{'::r1soft::agent::keys':} ->
   anchor {'r1soft::agent::end':}
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -37,7 +37,8 @@ inherits r1soft::params {
   class{'::r1soft::agent::kernel_package':} ->
   class{'::r1soft::agent::install':} ->
   class{'::r1soft::agent::service':} ->
-  class{'::r1soft::agent::hcpdriver':} ->
   class{'::r1soft::agent::keys':} ->
   anchor {'r1soft::agent::end':}
+
+  class{'::r1soft::agent::hcpdriver':}
 }

--- a/manifests/agent/hcpdriver.pp
+++ b/manifests/agent/hcpdriver.pp
@@ -1,0 +1,18 @@
+class r1soft::agent::hcpdriver {
+  # check for the hcpdriver_installed fact to prevent weirdness on fresh
+  # installs
+  if ($r1soft::agent::kmod_manage and $::facts['hcpdriver_installed']) {
+    exec {'update hcpdriver kmod':
+      command => "${r1soft::agent::kmod_tool} --get-module --silent",
+      creates => $::facts['hcpdriver']['kmod_wanted'],
+      notify => Service[$r1soft::agent::service_name],
+    }
+
+    unless ($::facts['hcpdriver']['is_loaded'] and $::facts['hcpdriver']['kmod_wanted'] == $::facts['hcpdriver']['kmod_selected']) {
+      exec {'trigger cdp-agent restart':
+        command => '/bin/true',
+        notify => Service[$r1soft::agent::service_name],
+      }
+    }
+  }
+}

--- a/manifests/agent/hcpdriver.pp
+++ b/manifests/agent/hcpdriver.pp
@@ -1,17 +1,17 @@
 class r1soft::agent::hcpdriver {
   # check for the hcpdriver_installed fact to prevent weirdness on fresh
   # installs
-  if ($r1soft::agent::kmod_manage and $::facts['hcpdriver_installed']) {
+  if ($r1soft::agent::kmod_manage and $facts['hcpdriver_installed']) {
     exec {'update hcpdriver kmod':
       command => "${r1soft::agent::kmod_tool} --get-module --silent",
-      creates => $::facts['hcpdriver']['kmod_wanted'],
-      notify => Service[$r1soft::agent::service_name],
+      creates => $facts['hcpdriver']['kmod_wanted'],
+      notify  => Service[$r1soft::agent::service_name],
     }
 
-    unless ($::facts['hcpdriver']['is_loaded'] and $::facts['hcpdriver']['kmod_wanted'] == $::facts['hcpdriver']['kmod_selected']) {
+    unless ($facts['hcpdriver']['is_loaded'] and $facts['hcpdriver']['kmod_wanted'] == $facts['hcpdriver']['kmod_selected']) {
       exec {'trigger cdp-agent restart':
         command => '/bin/true',
-        notify => Service[$r1soft::agent::service_name],
+        notify  => Service[$r1soft::agent::service_name],
       }
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class r1soft::params {
   $keys                       = {}
   $keys_purge_unmanaged       = false
 
-  $agent_kmod_tool            = '/usr/sbin/hcp-setup'
+  $agent_kmod_tool            = '/usr/bin/r1soft-setup'
   $agent_kmod_manage          = false
 
   $server_package_version     = 'present'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,9 @@ class r1soft::params {
   $keys                       = {}
   $keys_purge_unmanaged       = false
 
+  $agent_kmod_tool            = '/usr/sbin/hcp-setup'
+  $agent_kmod_manage          = false
+
   $server_package_version     = 'present'
   $server_package_name        = 'serverbackup-enterprise'
   $server_service_manage      = true

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -32,9 +32,9 @@ inherits r1soft::params {
   }
 
 
-  anchor {'r1soft::server::begin':} ->
-  class{'::r1soft::server::install':} ->
-  class{'::r1soft::server::config':} ->
-  class{'::r1soft::server::service':} ->
-  anchor {'r1soft::server::end':}
+  anchor {'r1soft::server::begin':}
+  -> class{'::r1soft::server::install':}
+  -> class{'::r1soft::server::config':}
+  -> class{'::r1soft::server::service':}
+  -> anchor {'r1soft::server::end':}
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "nexcess-r1soft",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "nexcess",
   "summary": "Install and configure r1soft server and/or agent",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds an option for the agent class to request a new hcpdriver kmod when there isn't one already existing for the running kernel (determined by `uname -r`), and restarts the `cdp-agent` service when:
  - a new kmod was built *or*
  - the hcpdriver kmod isn't loaded *or*
  - `cdp-agent` isn't aware of the new kmod (determined by the `/lib/modules/r1soft/hcpdriver.o` symlink pointing to the wrong file)

Adds two new hiera values:
  - `r1soft::agent::kmod_manage`: defaults to `false`, controls the kmod management logic
  - `r1soft::agent::kmod_tool`: defaults to `/usr/sbin/hcp-setup`, the tool used to request new kmod builds (older versions of cdp-agent used a different tool IIRC, and we may eventually want to use a custom tool for this for caching builds)