### PR TITLE
Add Module Build Delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Specify the path to the hcp kmod build/retrieval tool: Default value: `/usr/bin/
 #### `kmod_manage`
 Specify if you want puppet to trigger kmod builds (and service restarts): Default value: false
 
+#### `delay_factor`
+Uptime (in seconds) a node should report before compiling the kernel module: Default value: 0
 
 ### r1soft::server parameters
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,32 +1,19 @@
 class r1soft::agent (
-  $repo_install               = $r1soft::params::repo_install,
-  $package_version            = $r1soft::params::agent_package_version,
-  $package_name               = $r1soft::params::agent_package_name,
-  $kernel_devel_install       = $r1soft::params::kernel_devel_install,
-  $kernel_devel_package_names = $r1soft::params::kernel_devel_package_names,
-  $service_manage             = $r1soft::params::agent_service_manage,
-  $service_name               = $r1soft::params::agent_service_name,
-  $service_ensure             = $r1soft::params::agent_service_ensure,
-  $service_enable             = $r1soft::params::agent_service_enable,
-  $keys                       = $r1soft::params::keys,
-  $keys_purge_unmanaged       = $r1soft::params::keys_purge_unmanaged,
-  $kmod_tool                  = $r1soft::params::agent_kmod_tool,
-  $kmod_manage                = $r1soft::params::agent_kmod_manage,
+  Boolean $repo_install              = $r1soft::params::repo_install,
+  String $package_version            = $r1soft::params::agent_package_version,
+  String $package_name               = $r1soft::params::agent_package_name,
+  Boolean $kernel_devel_install      = $r1soft::params::kernel_devel_install,
+  String $kernel_devel_package_names = $r1soft::params::kernel_devel_package_names,
+  Boolean $service_manage            = $r1soft::params::agent_service_manage,
+  String $service_name               = $r1soft::params::agent_service_name,
+  String $service_ensure             = $r1soft::params::agent_service_ensure,
+  Boolean $service_enable            = $r1soft::params::agent_service_enable,
+  Hash $keys                         = $r1soft::params::keys,
+  Boolean $keys_purge_unmanaged      = $r1soft::params::keys_purge_unmanaged,
+  String $kmod_tool                  = $r1soft::params::agent_kmod_tool,
+  Boolean $kmod_manage               = $r1soft::params::agent_kmod_manage,
 )
 inherits r1soft::params {
-  validate_bool($repo_install)
-  validate_string($package_version)
-  validate_string($package_name)
-  validate_bool($kernel_devel_install)
-  validate_string($kernel_devel_package_names)
-  validate_bool($service_manage)
-  validate_string($service_name)
-  validate_string($service_ensure)
-  validate_bool($service_enable)
-  validate_hash($keys)
-  validate_bool($keys_purge_unmanaged)
-  validate_string($kmod_tool)
-  validate_bool($kmod_manage)
 
   if $repo_install {
     include r1soft::repo

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -12,6 +12,7 @@ class r1soft::agent (
   Boolean $keys_purge_unmanaged      = $r1soft::params::keys_purge_unmanaged,
   String $kmod_tool                  = $r1soft::params::agent_kmod_tool,
   Boolean $kmod_manage               = $r1soft::params::agent_kmod_manage,
+  Integer $delay_factor              = $r1soft::params::agent_delay_module_build_factor
 )
 inherits r1soft::params {
 

--- a/manifests/agent/hcpdriver.pp
+++ b/manifests/agent/hcpdriver.pp
@@ -1,17 +1,21 @@
 class r1soft::agent::hcpdriver {
-  # check for the hcpdriver_installed fact to prevent weirdness on fresh
-  # installs
-  if ($r1soft::agent::kmod_manage and $facts['hcpdriver_installed']) {
-    exec {'update hcpdriver kmod':
-      command => "${r1soft::agent::kmod_tool} --get-module --silent",
-      creates => $facts['hcpdriver']['kmod_wanted'],
-      notify  => Service[$r1soft::agent::service_name],
-    }
 
-    unless ($facts['hcpdriver']['is_loaded'] and $facts['hcpdriver']['kmod_wanted'] == $facts['hcpdriver']['kmod_selected']) {
-      exec {'trigger cdp-agent restart':
-        command => '/bin/true',
-        notify  => Service[$r1soft::agent::service_name],
+  if $r1soft::agent::kmod_manage {
+    if $facts['system_uptime']['seconds'] >= $r1soft::agent::delay_factor {
+      # check for the hcpdriver_installed fact to prevent weirdness on fresh installs
+      if $facts['hcpdriver_installed'] {
+        exec {'update hcpdriver kmod':
+          command => "${r1soft::agent::kmod_tool} --get-module --silent",
+          creates => $facts['hcpdriver']['kmod_wanted'],
+          notify  => Service[$r1soft::agent::service_name],
+        }
+
+        unless ($facts['hcpdriver']['is_loaded'] and $facts['hcpdriver']['kmod_wanted'] == $facts['hcpdriver']['kmod_selected']) {
+          exec {'trigger cdp-agent restart':
+            command => '/bin/true',
+            notify  => Service[$r1soft::agent::service_name],
+          }
+        }
       }
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,25 +26,26 @@ class r1soft::params {
   } else {
     $kernel_devel_package_names = "kernel-devel-${::kernelrelease}"
   }
-  $agent_service_manage       = true
-  $agent_service_name         = 'cdp-agent'
-  $agent_service_ensure       = 'running'
-  $agent_service_enable       = true
-  $keys                       = {}
-  $keys_purge_unmanaged       = false
+  $agent_service_manage            = true
+  $agent_service_name              = 'cdp-agent'
+  $agent_service_ensure            = 'running'
+  $agent_service_enable            = true
+  $agent_delay_module_build_factor = 0
+  $keys                            = {}
+  $keys_purge_unmanaged            = false
 
-  $agent_kmod_tool            = '/usr/bin/r1soft-setup'
-  $agent_kmod_manage          = false
+  $agent_kmod_tool                 = '/usr/bin/r1soft-setup'
+  $agent_kmod_manage               = false
 
-  $server_package_version     = 'present'
-  $server_package_name        = 'serverbackup-enterprise'
-  $server_service_manage      = true
-  $server_service_name        = 'cdp-server'
-  $server_service_ensure      = 'running'
-  $server_service_enable      = true
-  $server_admin_user          = 'admin'
-  $server_admin_pass          = false
-  $server_max_mem             = undef
-  $server_http_port           = 80
-  $server_https_port          = 443
+  $server_package_version          = 'present'
+  $server_package_name             = 'serverbackup-enterprise'
+  $server_service_manage           = true
+  $server_service_name             = 'cdp-server'
+  $server_service_ensure           = 'running'
+  $server_service_enable           = true
+  $server_admin_user               = 'admin'
+  $server_admin_pass               = false
+  $server_max_mem                  = undef
+  $server_http_port                = 80
+  $server_https_port               = 443
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,30 +1,18 @@
 class r1soft::server (
-  $repo_install    = $r1soft::params::repo_install,
-  $package_version = $r1soft::params::server_package_version,
-  $package_name    = $r1soft::params::server_package_name,
-  $service_manage  = $r1soft::params::server_service_manage,
-  $service_name    = $r1soft::params::server_service_name,
-  $service_ensure  = $r1soft::params::server_service_ensure,
-  $service_enable  = $r1soft::params::server_service_enable,
-  $admin_user      = $r1soft::params::server_admin_user,
-  $admin_pass      = $r1soft::params::server_admin_pass,
-  $max_mem         = $r1soft::params::server_max_mem,
-  $http_port       = $r1soft::params::server_http_port,
-  $https_port      = $r1soft::params::server_https_port,
+  Boolean $repo_install   = $r1soft::params::repo_install,
+  String $package_version = $r1soft::params::server_package_version,
+  String $package_name    = $r1soft::params::server_package_name,
+  Boolean $service_manage = $r1soft::params::server_service_manage,
+  String $service_name    = $r1soft::params::server_service_name,
+  String $service_ensure  = $r1soft::params::server_service_ensure,
+  Boolean $service_enable = $r1soft::params::server_service_enable,
+  String $admin_user      = $r1soft::params::server_admin_user,
+  String $admin_pass      = $r1soft::params::server_admin_pass,
+  String $max_mem         = $r1soft::params::server_max_mem,
+  Integer $http_port      = $r1soft::params::server_http_port,
+  Integer $https_port     = $r1soft::params::server_https_port,
 )
 inherits r1soft::params {
-  validate_bool($repo_install)
-  validate_string($package_version)
-  validate_string($package_name)
-  validate_bool($service_manage)
-  validate_string($service_name)
-  validate_string($service_ensure)
-  validate_bool($service_enable)
-  validate_string($admin_user)
-  validate_string($admin_pass)
-  validate_string($max_mem)
-  validate_integer($http_port)
-  validate_integer($https_port)
 
   if $repo_install {
     include r1soft::repo


### PR DESCRIPTION
Allows for a delay to be set before including the actual commands to build the kernel modules. The main reason for this, is that on some nodes an initial Puppet run can take a very long time, or sometimes just not complete at all, depending on the service at R1's end.

This allows for that dependency to be removed, at least to the extent of getting a system initially managed. The default is 0, which should just mimic the behavior that is currently in place.