### PR TITLE
simplify tests and bump versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,32 +23,10 @@ matrix:
     script: bundle exec rake beaker
     services: docker
     sudo: required
-
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 3.0"   STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 4.0"   STRICT_VARIABLES=yes
-
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
   - rvm: 2.1
     env: PUPPET_GEM_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 4.2.0" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 4.3.0" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 4.4.0" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 4.5.0" STRICT_VARIABLES=yes
+  - rvm: 2.4
+    env: PUPPET_GEM_VERSION="~> 5.0.0" STRICT_VARIABLES=yes
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 notifications:
   email: false

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "nexcess-r1soft",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "author": "nexcess",
   "summary": "Install and configure r1soft server and/or agent",
   "license": "Apache-2.0",
@@ -16,7 +16,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -24,7 +23,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -33,13 +31,13 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.2.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
Remove support for EL5 and Puppet 3. Simplify the tests ran in Travis (still expect them to fail right now) to just test Puppet 4 and 5.

We also bump some required versions and up the release version to prep for 3.0 release.