### PR TITLE
2020-02-28T13:55-0500 | Only restart if the wanted module is built

### DIFF
--- a/manifests/agent/hcpdriver.pp
+++ b/manifests/agent/hcpdriver.pp
@@ -10,7 +10,11 @@ class r1soft::agent::hcpdriver {
           notify  => Service[$r1soft::agent::service_name],
         }
 
-        unless ($facts['hcpdriver']['is_loaded'] and $facts['hcpdriver']['kmod_wanted'] == $facts['hcpdriver']['kmod_selected']) {
+        unless (
+          $facts['hcpdriver']['is_loaded'] and
+          $facts['hcpdriver']['kmod_wanted'] == $facts['hcpdriver']['kmod_selected'] and
+          $facts['hcpdriver']['kmod_wanted_is_built']
+        ) {
           exec {'trigger cdp-agent restart':
             command => '/bin/true',
             notify  => Service[$r1soft::agent::service_name],


### PR DESCRIPTION
Will prevent constant service restarts on containerhosts: 

**Facts output on containerhost-136588.us-midwest-1.nxcli.net**
~~~bash
 328     "hcpdriver": {                                                                                  
 329       "is_loaded": false,                                                                           
 330       "kmod_wanted": "/lib/modules/r1soft/hcpdriver-cki-4.4.214-1.el7.elrepo.x86_64.ko",            
 331       "kmod_wanted_is_built": false,                                                                
 332       "kmod_selected": ""                                                                           
 333     }, 
~~~

**Puppet log entries on containerhost-136588.us-midwest-1.nxcli.net**
~~~bash
436 2020-02-28 11:08:45 -0500 /Stage[main]/R1soft::Agent::Hcpdriver/Exec[update hcpdriver kmod]/returns (notice): executed successfully
437 2020-02-28 11:08:45 -0500 /Stage[main]/R1soft::Agent::Hcpdriver/Exec[trigger cdp-agent restart]/returns (notice): executed successfully
438 2020-02-28 11:10:01 -0500 /Stage[main]/R1soft::Agent::Service/Service[cdp-agent] (notice): Triggered 'refresh' from 2 events
439 2020-02-28 11:10:08 -0500 Puppet (notice): Applied catalog in 160.90 seconds                        
440 2020-02-28 12:07:02 -0500 Puppet (err): Unable to set ownership to puppet:puppet for log file: /var/log/puppet/agent.log
441 2020-02-28 12:08:53 -0500 /Stage[main]/R1soft::Agent::Hcpdriver/Exec[update hcpdriver kmod]/returns (notice): executed successfully
442 2020-02-28 12:08:53 -0500 /Stage[main]/R1soft::Agent::Hcpdriver/Exec[trigger cdp-agent restart]/returns (notice): executed successfully
443 2020-02-28 12:10:14 -0500 /Stage[main]/R1soft::Agent::Service/Service[cdp-agent] (notice): Triggered 'refresh' from 2 events
444 2020-02-28 12:10:24 -0500 Puppet (notice): Applied catalog in 173.72 seconds 
~~~