### PR TITLE
Update r1soft commit 3

### DIFF
--- a/manifests/agent/hcpdriver.pp
+++ b/manifests/agent/hcpdriver.pp
@@ -7,7 +7,7 @@ class r1soft::agent::hcpdriver {
       if $facts['hcpdriver_installed'] {
         exec {'update hcpdriver kmod':
           command => "${r1soft::agent::kmod_tool} --get-module --silent",
-          creates => $facts['hcpdriver']['kmod_wanted'],
+          creates => $facts['hcpdriver']['kmod_wanted']
         }
 
         ## If the module isn't built, don't even continue
@@ -18,7 +18,7 @@ class r1soft::agent::hcpdriver {
           ) {
             exec {'trigger cdp-agent restart':
               command => '/bin/true',
-              notify  => Service[$r1soft::agent::service_name],
+              notify  => Service[$r1soft::agent::service_name]
             }
           }
         }

--- a/manifests/agent/hcpdriver.pp
+++ b/manifests/agent/hcpdriver.pp
@@ -3,11 +3,11 @@ class r1soft::agent::hcpdriver {
   if $r1soft::agent::kmod_manage {
     if $facts['system_uptime']['seconds'] >= $r1soft::agent::delay_factor {
       # check for the hcpdriver_installed fact to prevent weirdness on fresh installs
+      # do not notify service here, since a failure on the command could still provide a return code of 0
       if $facts['hcpdriver_installed'] {
         exec {'update hcpdriver kmod':
           command => "${r1soft::agent::kmod_tool} --get-module --silent",
           creates => $facts['hcpdriver']['kmod_wanted'],
-          notify  => Service[$r1soft::agent::service_name],
         }
 
         ## If the module isn't built, don't even continue


### PR DESCRIPTION
Remove the notify because _pretty_ sure that a sucessful module build restarts the service, and most importantly, 

**r1soft scripts are stupid**
~~~bash

[15:06:49][containerhost-136588.us-midwest-1.nxcli.net][root][/home/nexcess.net/esimpkins]$ /usr/bin/r1soft-setup --get-module                                                                                                                
Checking if module needs updated
Checking for binary module
Waiting                       /          
No binary module found
Gathering kernel information
Gathering kernel information complete.
Creating kernel headers package
Checking '/lib/modules/4.4.214-1.el7.elrepo.x86_64/source/' for kernel headers
Found headers in '/lib/modules/4.4.214-1.el7.elrepo.x86_64/source/'
Compressing...
uploading kernel package                                                                                                                                                                                     99% 9348KB   9.1MB/s   00:00 ETA
Starting module build...
Building                      /          kernel module installer failed. (0): 
Internal error encountered. Please contact support
Request ID: (418db217-ff9e-4d66-99d4-d02e6842997f)
http://www.r1soft.com/distros/index.php?uuid=418db217-ff9e-4d66-99d4-d02e6842997f

[15:10:29][containerhost-136588.us-midwest-1.nxcli.net][root][/home/nexcess.net/esimpkins]$ echo $?
0
~~~