### PR TITLE
2020-03-04T16:18-0500 | Remove conditional from service manifest

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -1,10 +1,8 @@
 class r1soft::agent::service {
   if $r1soft::agent::service_manage {
-    if $facts['system_uptime']['seconds'] >= $r1soft::agent::delay_factor {
-      service { $r1soft::agent::service_name:
-        ensure => $r1soft::agent::service_ensure,
-        enable => $r1soft::agent::service_enable,
-      }
+    service { $r1soft::agent::service_name:
+      ensure => $r1soft::agent::service_ensure,
+      enable => $r1soft::agent::service_enable,
     }
   }
 }


### PR DESCRIPTION
This was handled in the puppet-config side by PR [6414](https://github.com/nexcess/puppet-config/pull/6414/files). Handling it here will prevent evaluation of the chkconfig/service state until after the delay; this leads to the following manifests/resources being run (in no specific order): 

~~~bash
$ grep -Eo 'R1soft.*?: ' /root/puppet.log | perl -pe 's,\[[^\x5B]+\], ,g; s,/ensure.*$,,' | sort -u
R1soft::Agent::Install/Package 
R1soft::Agent::Kernel_package/Package 
R1soft::Agent::Keys/R1soft::Agent::Key /File 
R1soft::Repo/Yumrepo 
~~~

This will allow management of the service chkconfig value, thereby preventing telegraf from alerting upon new builds